### PR TITLE
chore: release v0.3.12

### DIFF
--- a/config/docuhost.yaml
+++ b/config/docuhost.yaml
@@ -3,7 +3,7 @@ app:
 db:
   prefix: mongodb
   user: ${DB_USER}
-  password: $[DB_PASSWORD]
+  password: ${DB_PASSWORD}
   host: localhost
   port: 27017
   name: documents


### PR DESCRIPTION
* bump go.mongodb.org/mongo-driver to 1.12.0
* fix typo in configuratiion file
* fix deprecated mongodb-driver syntax