### PR TITLE
chore: release v0.3.16

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ permissions:
   pull-requests: read
 
 env:
-  GO_VERSION: 1.20.5
+  GO_VERSION: 1.21.0
 
 jobs:
   # Check if there are any dirty changes for go mod tidy

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.5-bullseye AS build-env
+FROM golang:1.21.0-bullseye AS build-env
 
 ARG BUILD_VERSION=development
 ARG BUILD_REVISION=unknown


### PR DESCRIPTION
* bumps golang to v1.21.0