### PR TITLE
fix: golangci-lint flagging unused params

### DIFF
--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -28,7 +28,7 @@ var rootCmd = &cobra.Command{
 demo-generated documents for temporary storage. Documents can be retrieved via the
 short link returned in the upload response.
 `,
-	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+	PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
 		Config = &config.Configuration{}
 		if err := viper.UnmarshalExact(&Config); err != nil {
 			return errors.Wrapf(err, "failed to unmarshal config")

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -20,7 +20,7 @@ var serveCmd = &cobra.Command{
 	Short: "starts the API server",
 	Long: `Starts the HTTP(S) server on the configured port and exposes the API endpoints
 `,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, _ []string) {
 		log.WithField("server", root.Config.Server).Debug("starting API server")
 		app, err := api.NewApp(root.Config)
 		if err != nil {


### PR DESCRIPTION
fixes: #75